### PR TITLE
Fix SafeArgs long parsing error in navigation graph

### DIFF
--- a/app-marina/app/src/main/res/navigation/nav_graph.xml
+++ b/app-marina/app/src/main/res/navigation/nav_graph.xml
@@ -76,7 +76,7 @@
         <argument
             android:name="bookingId"
             app:argType="long"
-            android:defaultValue="0" />
+            android:defaultValue="0L" />
     </fragment>
 
     <fragment


### PR DESCRIPTION
## المشكلة / Problem
فشلت عملية البناء بسبب خطأ في SafeArgs:
```
error: Failed to parse defaultValue '0' as long
nav_graph.xml:76:8
```

## الحل / Solution
تم تغيير `defaultValue` من `'0'` إلى `'0L'` للـ argument من نوع `long`.

## التغييرات / Changes
- ✅ إصلاح قيمة افتراضية في `nav_graph.xml` السطر 79
- ✅ تغيير `android:defaultValue="0"` إلى `android:defaultValue="0L"`
- ✅ حل مشكلة SafeArgs التي كانت تمنع البناء

## الاختبار / Testing
هذا الإصلاح سيسمح لـ workflow بالبناء بنجاح.