### PR TITLE
Fix: Add missing Splash Screen dependency

### DIFF
--- a/app-marina/app/build.gradle.kts
+++ b/app-marina/app/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     val okhttpVersion = "5.0.0-alpha.14"
 
     implementation("androidx.core:core-ktx:1.13.1")
+    implementation("androidx.core:core-splashscreen:1.0.1")
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")


### PR DESCRIPTION
## المشكلة / Problem
فشل البناء بخطأ في موارد Splash Screen:
```
error: resource style/Theme.SplashScreen not found
error: style attribute 'attr/windowSplashScreenBackground' not found
error: style attribute 'attr/windowSplashScreenAnimatedIcon' not found
```

## السبب / Root Cause
التطبيق يستخدم Splash Screen API في theme configuration، لكن المكتبة المطلوبة غير موجودة في `build.gradle.kts`.

## الحل / Solution
تمت إضافة التبعية المفقودة:
```kotlin
implementation("androidx.core:core-splashscreen:1.0.1")
```

## التأثير / Impact
- ✅ يصلح خطأ البناء الحالي
- ✅ يُمكِّن Splash Screen API بشكل صحيح
- ✅ لا يؤثر على الكود الموجود

## Priority
🔴 **HIGH** - البناء لا يعمل بدون هذا الإصلاح