### PR TITLE
Fix: Add missing GridLayout dependency

### DIFF
--- a/app-marina/app/build.gradle.kts
+++ b/app-marina/app/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.7.0")
     implementation("com.google.android.material:material:1.12.0")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.gridlayout:gridlayout:1.0.0")
     implementation("androidx.recyclerview:recyclerview:1.3.2")
     implementation("androidx.cardview:cardview:1.0.0")
     implementation("androidx.activity:activity-ktx:1.9.0")


### PR DESCRIPTION
## المشكلة / Problem
فشل البناء بخطأ في `fragment_dashboard.xml`:
```
error: attribute layout_columnWeight not found
error: attribute layout_rowWeight not found
```

## السبب / Root Cause
التطبيق يستخدم `androidx.gridlayout.widget.GridLayout` في `fragment_dashboard.xml` لكن المكتبة المطلوبة غير موجودة في `build.gradle.kts`.

الخصائص `layout_columnWeight` و `layout_rowWeight` تتطلب:
- Parent: `androidx.gridlayout.widget.GridLayout`
- Dependency: `androidx.gridlayout:gridlayout`

## الحل / Solution
تمت إضافة التبعية المفقودة:
```kotlin
implementation("androidx.gridlayout:gridlayout:1.0.0")
```

## الملف المتأثر / Affected File
`app-marina/app/src/main/res/layout/fragment_dashboard.xml` - السطر 190-191

## التأثير / Impact
- ✅ يصلح خطأ البناء الحالي
- ✅ يُمكِّن GridLayout في Dashboard
- ✅ لا يؤثر على الكود الموجود

## Priority
🔴 **CRITICAL** - البناء لا يعمل بدون هذا الإصلاح